### PR TITLE
Update AbstractHandler.php

### DIFF
--- a/handlers/AbstractHandler.php
+++ b/handlers/AbstractHandler.php
@@ -2,14 +2,14 @@
 
 namespace cetver\LanguagesDispatcher\handlers;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class AbstractHandler is a simple handler implementation that other handlers can inherit from.
  *
  * @package cetver\LanguagesDispatcher\handlers
  */
-abstract class AbstractHandler extends Object
+abstract class AbstractHandler extends BaseObject
 {
     /**
      * Returns the list of languages detected by the handler.


### PR DESCRIPTION
It has been replaced by [[BaseObject]] in version 2.0.13 because `object` has become a reserved word which can not be
used as class name in PHP 7.2.