### PR TITLE
HostName Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ return [
             // Order is important
             'handlers' => [
                 [
+                    // Detects a language based on host name
+                    'class' => 'cetver\LanguagesDispatcher\handlers\HostNameHandler',
+                    'request' => 'request', // optional, the Request component ID.
+                    'hostMap' => [
+                        'ru.example.com' => 'ru',
+                        'uk.example.com' => 'uk'
+                    ]
+                ],
+                [
                     // Detects a language from the query parameter.
                     'class' => 'cetver\LanguagesDispatcher\handlers\QueryParamHandler',
                     'request' => 'request', // optional, the Request component ID.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ return [
                     // Detects a language based on host name
                     'class' => 'cetver\LanguagesDispatcher\handlers\HostNameHandler',
                     'request' => 'request', // optional, the Request component ID.
+                    // hostMap can be either an array or a callable that returns an array
                     'hostMap' => [
                         'ru.example.com' => 'ru',
                         'uk.example.com' => 'uk'

--- a/handlers/HostNameHandler.php
+++ b/handlers/HostNameHandler.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace cetver\LanguagesDispatcher\handlers;
+
+use Yii;
+use yii\base\InvalidConfigException;
+use yii\helpers\ArrayHelper;
+use yii\web\Request;
+
+/**
+ * Class HostNameHandler
+ *
+ * @package cetver\LanguagesDispatcher\handlers
+ *
+ * @property array          $hostMap
+ * @property array          $_languages
+ * @property Request|string $request
+ */
+class HostNameHandler extends AbstractHandler
+{
+    /**
+     * @var string|Request the Request component ID.
+     */
+    public $request = 'request';
+
+    /** @var array
+     *
+     * key represents the host name and the value represents the language code
+     */
+    public $hostMap = [];
+
+    /**
+     * @var array
+     */
+    private $_languages = [];
+
+    /**
+     * @inheritdoc
+     */
+    function init()
+    {
+        parent::init();
+
+        $request = Yii::$app->get($this->request, false);
+        if (!$request instanceof Request) {
+            throw new InvalidConfigException(sprintf(
+                'The component with the specified ID "%s" must be an instance of "%s"',
+                $this->request,
+                Request::class
+            ));
+        }
+
+        $this->request = $request;
+
+        if (!is_array($this->hostMap)) throw new InvalidConfigException("hostMap must be an array");
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLanguages()
+    {
+        if (empty($this->_languages)) {
+            try {
+                // other handlers will populate this
+                $this->_languages[] = $this->hostMap[$this->request->hostName];
+            } catch (\Exception $exception) {
+                Yii::error($exception->getMessage());
+            }
+        }
+
+        return ArrayHelper::merge(parent::getLanguages(), $this->_languages);
+    }
+}

--- a/handlers/HostNameHandler.php
+++ b/handlers/HostNameHandler.php
@@ -46,7 +46,7 @@ class HostNameHandler extends AbstractHandler
             throw new InvalidConfigException(sprintf(
                 'The component with the specified ID "%s" must be an instance of "%s"',
                 $this->request,
-                Request::class
+                Request::className()
             ));
         }
 

--- a/tests/unit/handlers/HostNameHandlerTest.php
+++ b/tests/unit/handlers/HostNameHandlerTest.php
@@ -17,14 +17,16 @@ class HostNameHandlerTest extends AbstractUnitTest
     public function testInit()
     {
         $request = 'invalid-request';
-        $this->tester->expectException(InvalidConfigException::class, function () use ($request) {
+        $invalidConfigExceptionClassName = ((new \ReflectionClass(new InvalidConfigException()))->getName());
+
+        $this->tester->expectException($invalidConfigExceptionClassName, function () use ($request) {
             $this->mockWebApplication();
             new HostNameHandler([
                 'request' => $request,
             ]);
         });
 
-        $this->tester->expectException(InvalidConfigException::class, function () {
+        $this->tester->expectException($invalidConfigExceptionClassName, function () {
             $this->mockWebApplication();
             new HostNameHandler([
                 'hostMap' => 'whatever'
@@ -32,7 +34,7 @@ class HostNameHandlerTest extends AbstractUnitTest
         });
 
         $handler = new HostNameHandler();
-        $this->tester->assertInstanceOf(Request::class, $handler->request);
+        $this->tester->assertInstanceOf(Request::className(), $handler->request);
     }
 
     public function testGetLanguages()

--- a/tests/unit/handlers/HostNameHandlerTest.php
+++ b/tests/unit/handlers/HostNameHandlerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace cetver\LanguagesDispatcher\tests\unit\handlers;
+
+use cetver\LanguagesDispatcher\handlers\HostNameHandler;
+use cetver\LanguagesDispatcher\tests\AbstractUnitTest;
+use yii\base\InvalidConfigException;
+use yii\web\Request;
+
+/**
+ * Class HostHandlerTest
+ *
+ * @package cetver\LanguagesDispatcher\tests\unit\handlers
+ */
+class HostNameHandlerTest extends AbstractUnitTest
+{
+    public function testInit()
+    {
+        $request = 'invalid-request';
+        $this->tester->expectException(InvalidConfigException::class, function () use ($request) {
+            $this->mockWebApplication();
+            new HostNameHandler([
+                'request' => $request,
+            ]);
+        });
+
+        $this->tester->expectException(InvalidConfigException::class, function () {
+            $this->mockWebApplication();
+            new HostNameHandler([
+                'hostMap' => 'whatever'
+            ]);
+        });
+
+        $handler = new HostNameHandler();
+        $this->tester->assertInstanceOf(Request::class, $handler->request);
+    }
+
+    public function testGetLanguages()
+    {
+        $this->mockWebApplication();
+
+
+        $handler = new HostNameHandler([
+            'hostMap' => [
+                'ru.example.com'   => 'ru',
+            ]
+        ]);
+
+        $handler->request->setHostInfo('http://uk.example.com');
+        $this->tester->assertSame([], $handler->getLanguages());
+
+        $handler->request->setHostInfo('https://ru.example.com');
+        $this->tester->assertSame(['ru'], $handler->getLanguages());
+    }
+}

--- a/tests/unit/handlers/HostNameHandlerTest.php
+++ b/tests/unit/handlers/HostNameHandlerTest.php
@@ -16,8 +16,8 @@ class HostNameHandlerTest extends AbstractUnitTest
 {
     public function testInit()
     {
-        $request = 'invalid-request';
-        $invalidConfigExceptionClassName = ((new \ReflectionClass(new InvalidConfigException()))->getName());
+        $request                         = 'invalid-request';
+        $invalidConfigExceptionClassName = get_class(new InvalidConfigException());
 
         $this->tester->expectException($invalidConfigExceptionClassName, function () use ($request) {
             $this->mockWebApplication();
@@ -29,23 +29,42 @@ class HostNameHandlerTest extends AbstractUnitTest
         $this->tester->expectException($invalidConfigExceptionClassName, function () {
             $this->mockWebApplication();
             new HostNameHandler([
-                'hostMap' => 'whatever'
+                'hostMap' => 'non-array'
             ]);
         });
 
+        $this->tester->expectException($invalidConfigExceptionClassName, function () {
+            $this->mockWebApplication();
+            new HostNameHandler([
+                'hostMap' => function () {
+                    return false;
+                }
+            ]);
+        });
+
+        $handler = new HostNameHandler([
+            'hostMap' => function () {
+                return [
+                    'ru.example.com' => 'ru'
+                ];
+            }
+        ]);
+        $this->tester->assertArrayHasKey('ru.example.com', $handler->hostMap);
+
         $handler = new HostNameHandler();
-        $this->tester->assertInstanceOf(Request::className(), $handler->request);
+        $this->tester->assertInstanceOf(get_class(new Request()), $handler->request);
     }
 
     public function testGetLanguages()
     {
+        $hostMap = [
+            'ru.example.com' => 'ru',
+            'cn.example.com' => 'cn'
+        ];
+
         $this->mockWebApplication();
-
-
         $handler = new HostNameHandler([
-            'hostMap' => [
-                'ru.example.com'   => 'ru',
-            ]
+            'hostMap' => $hostMap
         ]);
 
         $handler->request->setHostInfo('http://uk.example.com');
@@ -53,5 +72,18 @@ class HostNameHandlerTest extends AbstractUnitTest
 
         $handler->request->setHostInfo('https://ru.example.com');
         $this->tester->assertSame(['ru'], $handler->getLanguages());
+
+        $this->mockWebApplication();
+        $handler = new HostNameHandler([
+            'hostMap' => function () use ($hostMap) {
+                return $hostMap;
+            }
+        ]);
+
+        $handler->request->setHostInfo('http://ro.example.com');
+        $this->tester->assertSame([], $handler->getLanguages());
+
+        $handler->request->setHostInfo('https://cn.example.com');
+        $this->tester->assertSame(['cn'], $handler->getLanguages());
     }
 }


### PR DESCRIPTION
Added the possibility of detecting language based on host name. A lot of sites use alternative URLs because the content is completely different based on the host. 

See `README.md`.